### PR TITLE
Retain proper case sensitivity of the comment

### DIFF
--- a/mod_pbxproj/mod_pbxproj.py
+++ b/mod_pbxproj/mod_pbxproj.py
@@ -992,7 +992,7 @@ class XcodeProject(PBXDict):
                         self.remove_group(childKey, True)
                     else:
                         self.remove_file(childKey, False)
-            
+
         self.objects.remove(id);
 
     def remove_group_by_name(self, name, recursive = False):
@@ -1238,7 +1238,7 @@ class XcodeProject(PBXDict):
                     uuids[key] = 'Build configuration list for PBXNativeTarget "TARGET_NAME"'
 
         ro = self.data.get('rootObject')
-        uuids[ro] = 'Project Object'
+        uuids[ro] = 'Project object'
 
         for key in objs:
             # transitive references (used in the BuildFile section)


### PR DESCRIPTION
Retain proper case sensitivity of the comment. Some folks (Unity, I'm looking at you!) use the comments for the parsing of the file.