### PR TITLE
don't escape $(inherited) in any type of search path

### DIFF
--- a/mod_pbxproj/mod_pbxproj.py
+++ b/mod_pbxproj/mod_pbxproj.py
@@ -468,6 +468,9 @@ class XCBuildConfiguration(PBXType):
             elif isinstance(self[base][key], basestring):
                 self[base][key] = PBXList(self[base][key])
 
+            if path == '$(inherited)':
+                escape = False
+
             if escape:
                 if self[base][key].add('"%s"' % path):  # '\\"%s\\"' % path
                     modified = True


### PR DESCRIPTION
It causes random missing framework header issues