### PR TITLE
Added functions XCBuildConfiguration.add_other_buildsetting and Xcode…

### DIFF
--- a/mod_pbxproj/mod_pbxproj.py
+++ b/mod_pbxproj/mod_pbxproj.py
@@ -545,6 +545,21 @@ class XCBuildConfiguration(PBXType):
     def remove_other_ldflags(self, flags):
         return self.remove_flag('OTHER_LD_FLAGS', flags)
 
+# Set one option under buildSettings root
+    def add_other_buildsetting(self, flag, value):
+        modified = False
+        base = 'buildSettings'
+        key = flag
+         
+        if not self.has_key(base):
+            self[base] = PBXDict()
+        if self[base].has_key(key):
+            if self[base][key] == value:
+                return False
+        self[base][key] = value                             
+        modified = True
+        return modified
+
 class XCConfigurationList(PBXType):
     pass
 
@@ -633,6 +648,15 @@ class XcodeProject(PBXDict):
             for k in pairs:
                 if b.add_flag(k, pairs[k]):
                     self.modified = True
+
+# Set one option under buildSettings root
+    def add_other_buildsetting(self, flag, value):
+        build_configs = [b for b in self.objects.values() if b.get('isa') == 'XCBuildConfiguration']
+        
+        for b in build_configs:
+            if b.add_other_buildsetting(flag, value):
+                self.modified = True
+
 
     def remove_flags(self, pairs, configuration='All'):
         build_configs = [b for b in self.objects.values() if b.get('isa') == 'XCBuildConfiguration']


### PR DESCRIPTION
…Project.add_other_buildsetting.

Maybe these are obsolete but did not figure out how to set a single option like 'ENABLE_BITCODE = NO'.


(Making the PR for this guy because I also had this need - in my case I want to set `CLANG_ENABLE_MODULES = YES;` but can't, it makes `CLANG_ENABLE_MODULES = ( YES, ) ;` right now w/o this PR