### PR TITLE
Ignore files without a name in get_files_by_name()

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -196,7 +196,7 @@ class ProjectFiles:
 
         files = []
         for file_ref in self.objects.get_objects_in_section(u'PBXFileReference'):
-            if file_ref.name == name and (parent is None or parent.has_child(file_ref.get_id())):
+            if hasattr(file_ref, 'name') and file_ref.name == name and (parent is None or parent.has_child(file_ref.get_id())):
                 files.append(file_ref)
 
         return files

--- a/tests/pbxextensions/TestProjectFiles.py
+++ b/tests/pbxextensions/TestProjectFiles.py
@@ -26,6 +26,7 @@ class ProjectFilesTest(unittest.TestCase):
                 'file2': {'isa': 'PBXFileReference', 'name': 'file', 'path':'file', 'sourceTree': 'SOURCE_ROOT'},
                 'file3': {'isa': 'PBXFileReference', 'name': 'file', 'path':'file', 'sourceTree': 'SDKROOT'},
                 'file4': {'isa': 'PBXFileReference', 'name': 'file1', 'path': 'file1', 'sourceTree': 'SOURCE_ROOT'},
+                'file5': {'isa': 'PBXFileReference', 'path': 'file1', 'sourceTree': 'SOURCE_ROOT'},
                 'build_file1': {'isa': 'PBXBuildFile', 'fileRef': 'file1'},
                 'build_file2': {'isa': 'PBXBuildFile', 'fileRef': 'file2'},
                 'compile': {'isa': 'PBXGenericBuildPhase', 'files': ['build_file1']},


### PR DESCRIPTION
This addresses a crash in real-world settings where some files would have a 'path' attribute but no 'name' attribute. For example, having the following file ref in the pbxproj was causing a crash when using `get_files_by_name()`:

```txt
{isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVRedirectAction.h; sourceTree = "<group>"; }
```

An example stacktrace:

```txt
Traceback (most recent call last):
  File "./integrate.py", line 78, in <module>
    files = project.get_files_by_name('MyClass.m')
  File "/Users/david.legare/mod_pbxproj/pbxproj/pbxextensions/ProjectFiles.py", line 200, in get_files_by_name
    if file_ref.name == name and (parent is None or parent.has_child(file_ref.get_id())):
AttributeError: 'PBXFileReference' object has no attribute 'name'
```

That example `PBXFileReference` comes directly from my project. Note that it has no `name` attribute, but it does have a `path` attribute with the contents I'd expect to be in `name`. I don't know if this is a common occurrence in Xcode projects, so I opted to simply skip file refs that don't have `name`. If this isn't the best solution I'm happy to change it.