### PR TITLE
Variant groups

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -125,7 +125,7 @@ class ProjectFiles:
 
         # determine the parent and add it to it
         self._get_parent_group(parent).add_child(file_ref)
-        
+
         # no need to create the build_files, done
         if not file_options.create_build_files:
             return results

--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -125,7 +125,7 @@ class ProjectFiles:
 
         # determine the parent and add it to it
         self._get_parent_group(parent).add_child(file_ref)
-
+        
         # no need to create the build_files, done
         if not file_options.create_build_files:
             return results
@@ -325,6 +325,11 @@ class ProjectFiles:
         results = []
         # create the build file and add it to the phase
         for target_build_phase in build_phases:
+            # check to see if we already have a PBXBuildFile for this file_ref in this phase, if so
+            # don't create another one
+            if any(str(self.objects[str(build_file)].fileRef) == file_ref.get_id() for build_file in target_build_phase.files):
+                continue
+            
             build_file = PBXBuildFile.create(file_ref, attributes)
             self.objects[build_file.get_id()] = build_file
             target_build_phase.add_build_file(build_file)

--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -329,7 +329,7 @@ class ProjectFiles:
             # don't create another one
             if any(str(self.objects[str(build_file)].fileRef) == file_ref.get_id() for build_file in target_build_phase.files):
                 continue
-            
+
             build_file = PBXBuildFile.create(file_ref, attributes)
             self.objects[build_file.get_id()] = build_file
             target_build_phase.add_build_file(build_file)

--- a/pbxproj/pbxsections/PBXGroup.py
+++ b/pbxproj/pbxsections/PBXGroup.py
@@ -1,5 +1,6 @@
 from pbxproj.PBXGenericObject import *
 from pbxproj.pbxsections import *
+from pbxproj.pbxsections.PBXVariantGroup import *
 
 
 class PBXGroup(PBXGenericObject):
@@ -44,7 +45,7 @@ class PBXGroup(PBXGenericObject):
 
     def add_child(self, child):
         # if it's not the right type of children for the group
-        if not isinstance(child, PBXGroup) and not isinstance(child, PBXFileReference):
+        if not isinstance(child, PBXGroup) and not isinstance(child, PBXFileReference) and not isinstance(child, PBXVariantGroup):
             return False
 
         self.children.append(child.get_id())


### PR DESCRIPTION
This is an amended version of the variant groups branch. I'm not sure if this is the best way to submit changes.

While testing it, I noticed a few issues which are fixed in this pull request:

- attempting to add a PBXVariantGroup as a child of a PBXGroup gives an exception as it isn't one of the expected types.
- adding multiple localisation files adds duplicate PBXBuildFiles for the variant group, which causes builds to fail as Xcode tries to copy the same file repeatedly.

With these two fixes, I can confirm that the variant groups work as expected for our use case (localising the app icon name by localising the Info.plist file).

But...

One thing I did find is that the system will automatically add the variants to any existing variant group that exists with the same name - even when that variant group is for a different target. For example, our project has a 'tests' target that contains a InfoPlist.strings variant group that's stored in a separate folder. With the system as it is, any InfoPlist.strings files we add to the project get added to this variant group - even though we want to add them for our main target. This code in question is this:

```
for variant in self.objects.get_objects_in_section(u'PBXVariantGroup'):
    if variant.name == expected_name:
```
I don't entirely understand how all of this works, but to me this seems like the incorrect - or at least, unexpected behaviour. I believe you should be able to have multiple variant groups for the same file. I've worked around this by removing the exiting variant group.

I also noticed that adding a strings file that's outside the project causes an exception on this line in ProjectFiles.py - I have't fixed this: 

`library_path = os.path.join(u'$(SRCROOT)', os.path.split(file_ref.path)[0])`

AttributeError: 'PBXVariantGroup' object has no attribute 'path'