### PR TITLE
fix: embed frameworks on wrong copy files build phases

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -145,7 +145,8 @@ class ProjectFiles:
             if file_options.embed_framework and expected_build_phase == u'PBXFrameworksBuildPhase' and \
                     file_ref.lastKnownFileType == u'wrapper.framework':
                 embed_phase = target.get_or_create_build_phase(u'PBXCopyFilesBuildPhase',
-                                                               (PBXCopyFilesBuildPhaseNames.EMBEDDED_FRAMEWORKS,))
+                                                               search_parameters={'dstSubfolderSpec': '10'},
+                                                               create_parameters=(PBXCopyFilesBuildPhaseNames.EMBEDDED_FRAMEWORKS,))
                 # add runpath search flag
                 self.add_flags(XCBuildConfigurationFlags.LD_RUNPATH_SEARCH_PATHS,
                                u'$(inherited) @executable_path/Frameworks', target_name)

--- a/pbxproj/pbxsections/PBXCopyFilesBuildPhase.py
+++ b/pbxproj/pbxsections/PBXCopyFilesBuildPhase.py
@@ -7,7 +7,7 @@ class PBXCopyFilesBuildPhaseNames:
 
 class PBXCopyFilesBuildPhase(PBXGenericBuildPhase):
     @classmethod
-    def create(cls, name=None, files=None, dest_path=u'', dest_subfolder_spec=10):
+    def create(cls, name=None, files=None, dest_path=u'', dest_subfolder_spec='10'):
         return cls().parse({
             u'_id': cls._generate_id(),
             u'isa': cls.__name__,

--- a/pbxproj/pbxsections/PBXGenericTarget.py
+++ b/pbxproj/pbxsections/PBXGenericTarget.py
@@ -3,7 +3,7 @@ from pbxproj.pbxsections.PBXGenericBuildPhase import *
 
 
 class PBXGenericTarget(PBXGenericObject):
-    def get_or_create_build_phase(self, build_phase_type, create_parameters=()):
+    def get_or_create_build_phase(self, build_phase_type, search_parameters={}, create_parameters=()):
         result = []
         parent = self.get_parent()
 
@@ -12,8 +12,10 @@ class PBXGenericTarget(PBXGenericObject):
 
         for build_phase_id in self.buildPhases:
             target_build_phase = parent[build_phase_id]
-            current_build_phase = type(target_build_phase).__name__
-            if current_build_phase == build_phase_type:
+            current_build_phase = target_build_phase.isa
+
+            if current_build_phase == build_phase_type and \
+                    all(key in target_build_phase and target_build_phase[key] == search_parameters[key] for key in search_parameters):
                 result.append(target_build_phase)
 
         if result.__len__() == 0:

--- a/pbxproj/pbxsections/PBXGenericTarget.py
+++ b/pbxproj/pbxsections/PBXGenericTarget.py
@@ -3,9 +3,10 @@ from pbxproj.pbxsections.PBXGenericBuildPhase import *
 
 
 class PBXGenericTarget(PBXGenericObject):
-    def get_or_create_build_phase(self, build_phase_type, search_parameters={}, create_parameters=()):
+    def get_or_create_build_phase(self, build_phase_type, search_parameters=None, create_parameters=()):
         result = []
         parent = self.get_parent()
+        search_parameters = search_parameters if search_parameters is not None else {}
 
         if build_phase_type is None:
             return result

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='pbxproj',
         ]
       },
       url="http://github.com/kronenthaler/mod-pbxproj",
-      version='2.0.6',
+      version='2.0.7',
       license='MIT License',
       install_requires=['openstep_parser', 'docopt'],
       packages=find_packages(exclude=['tests']),

--- a/tests/pbxextensions/TestProjectFiles.py
+++ b/tests/pbxextensions/TestProjectFiles.py
@@ -308,6 +308,6 @@ class ProjectFilesTest(unittest.TestCase):
         project = XcodeProject(self.obj)
         self.assertEqual(project.objects.get_objects_in_section(u'PBXCopyFilesBuildPhase').__len__(), 1)
 
-        build_file = project.add_file('X.framework', file_options=FileOptions(embed_framework=True))
+        project.add_file('X.framework', file_options=FileOptions(embed_framework=True))
 
         self.assertEqual(project.objects.get_objects_in_section(u'PBXCopyFilesBuildPhase').__len__(), 3)


### PR DESCRIPTION
#142 embed frameworks on the copy files build phases that points to the Frameworks subfolder