### PR TITLE
fix: incorrect removal of shell script build phases on removal of file

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -281,8 +281,8 @@ class ProjectFiles:
                         # remove the build file from the phase
                         build_phase.remove_build_file(build_file)
 
-                # if the build_phase is empty remove it too
-                if build_phase.files.__len__() == 0:
+                # if the build_phase is empty remove it too, unless it's a shell script.
+                if build_phase.files.__len__() == 0 and build_phase.isa != u'PBXShellScriptBuildPhase':
                     # remove the build phase from the target
                     target.remove_build_phase(build_phase)
 

--- a/tests/pbxextensions/TestProjectFiles.py
+++ b/tests/pbxextensions/TestProjectFiles.py
@@ -31,6 +31,7 @@ class ProjectFilesTest(unittest.TestCase):
                 'build_file2': {'isa': 'PBXBuildFile', 'fileRef': 'file2'},
                 'compile': {'isa': 'PBXGenericBuildPhase', 'files': ['build_file1']},
                 'compile1': {'isa': 'PBXCopyFilesBuildPhase', 'files': ['build_file2']},
+                'compile2': {'isa': 'PBXShellScriptBuildPhase', 'files': []},
                 'project': {'isa': 'PBXProject'}
             }
         }
@@ -207,6 +208,19 @@ class ProjectFilesTest(unittest.TestCase):
 
     def testRemoveFileById(self):
         project = XcodeProject(self.obj)
+        original = project.__str__()
+        project.add_file("file.m")
+
+        file = project.get_files_by_name('file.m')[0]
+        result = project.remove_file_by_id(file.get_id())
+
+        self.assertTrue(result)
+        self.assertEqual(project.__str__(), original)
+
+    def testRemoveFileByIdKeepShellScriptBuildPhases(self):
+        project = XcodeProject(self.obj)
+        project.add_run_script('ls -la')
+
         original = project.__str__()
         project.add_file("file.m")
 


### PR DESCRIPTION
#155, the problem was when removing a file all "empty" (files.length == 0) where removed. Shell script build phases tend to have 0 files and it was being removed from the project and the target but not from the build phase as the file was not a match in the first place.

@markshep could you try out this PR?

