### PR TITLE
Fixed setting of non-existent PBXGenericObject attribute to empty

### DIFF
--- a/pbxproj/PBXGenericObject.py
+++ b/pbxproj/PBXGenericObject.py
@@ -134,7 +134,8 @@ class PBXGenericObject(object):
             if value.__len__() == 1:
                 value = value[0]
             if value.__len__() == 0:
-                delattr(self, key)
+                if hasattr(self, key):
+                    delattr(self, key)
                 return
 
         setattr(self, key, value)

--- a/tests/TestPBXGenericObject.py
+++ b/tests/TestPBXGenericObject.py
@@ -50,7 +50,16 @@ class PBXGenericObjectTest(unittest.TestCase):
         self.assertIsInstance(dobj["c"]["c1"], PBXKey)
         self.assertIsNone(dobj['X'])
 
-    def testSetItem(self):
+    def testSetItemNone(self):
+        obj = {}
+        dobj = PBXGenericObject().parse(obj)
+
+        self.assertIsNone(dobj['something'])
+
+        dobj['something'] = None
+        self.assertIsNone(dobj['something'])
+
+    def testSetItemString(self):
         obj = {}
         dobj = PBXGenericObject().parse(obj)
 
@@ -58,6 +67,33 @@ class PBXGenericObjectTest(unittest.TestCase):
 
         dobj['something'] = 'yes'
         self.assertEqual(dobj['something'], 'yes')
+
+    def testSetItemListOfZero(self):
+        obj = {}
+        dobj = PBXGenericObject().parse(obj)
+
+        self.assertIsNone(dobj['something'])
+
+        dobj['something'] = []
+        self.assertIsNone(dobj['something'])
+
+    def testSetItemListOfOne(self):
+        obj = {}
+        dobj = PBXGenericObject().parse(obj)
+
+        self.assertIsNone(dobj['something'])
+
+        dobj['something'] = ['yes']
+        self.assertEqual(dobj['something'], 'yes')
+
+    def testSetItemListOfTwo(self):
+        obj = {}
+        dobj = PBXGenericObject().parse(obj)
+
+        self.assertIsNone(dobj['something'])
+
+        dobj['something'] = ['yes', 'yes']
+        self.assertEqual(dobj['something'], ['yes', 'yes'])
 
     def testResolveComment(self):
         obj = {"a": {"name": "A"}, "b": {"path": "B"}, "c": {"c1": "FDDF6A571C68E5B100D7A645"}}


### PR DESCRIPTION
The first commit adds more tests, one of which triggers the issue.  The second commit fixes it.