### PR TITLE
Fixed crashed while reading pbxproj files which does contain unicode characters

### DIFF
--- a/pbxproj/XcodeProject.py
+++ b/pbxproj/XcodeProject.py
@@ -61,5 +61,5 @@ class XcodeProject(PBXGenericObject, ProjectFiles, ProjectFlags, ProjectGroups):
     @classmethod
     def load(cls, path):
         import openstep_parser as osp
-        tree = osp.OpenStepDecoder.ParseFromFile(open(path, 'r'))
+        tree = osp.OpenStepDecoder.ParseFromString(open(path, 'r').read().decode('UTF-8'))
         return XcodeProject(tree, path)

--- a/pbxproj/XcodeProject.py
+++ b/pbxproj/XcodeProject.py
@@ -1,5 +1,6 @@
 import shutil
 import datetime
+import sys
 from pbxproj.pbxextensions import *
 
 
@@ -61,5 +62,8 @@ class XcodeProject(PBXGenericObject, ProjectFiles, ProjectFlags, ProjectGroups):
     @classmethod
     def load(cls, path):
         import openstep_parser as osp
-        tree = osp.OpenStepDecoder.ParseFromString(open(path, 'r').read().decode('UTF-8'))
+        if sys.version_info > (3, 0):
+            tree = osp.OpenStepDecoder.ParseFromFile(open(path, 'r'))
+        else:
+            tree = osp.OpenStepDecoder.ParseFromString(open(path, 'r').read().decode('UTF-8'))
         return XcodeProject(tree, path)


### PR DESCRIPTION
This PR solves the issues of reading pbxproj files which contains unicode characters.