### PR TITLE
修复 脚本误改 xxxx.pbxproj 中的注释代码问题

### DIFF
--- a/pbxproj/XcodeProject.py
+++ b/pbxproj/XcodeProject.py
@@ -27,7 +27,7 @@ class XcodeProject(PBXGenericObject, ProjectFiles, ProjectFlags, ProjectGroups):
             path = self._pbxproj_path
 
         f = open(path, 'w')
-        f.write(self.__repr__())
+        f.write(self.__repr__() + "\n")
         f.close()
 
     def backup(self):

--- a/pbxproj/pbxsections/PBXShellScriptBuildPhase.py
+++ b/pbxproj/pbxsections/PBXShellScriptBuildPhase.py
@@ -18,4 +18,8 @@ class PBXShellScriptBuildPhase(PBXGenericBuildPhase):
         })
 
     def _get_comment(self):
-        return u'ShellScript'
+        key = "name";
+        if key in self:
+            return self[key];
+        else:
+            return u'ShellScript'


### PR DESCRIPTION
执行 下面两行代码
project = XcodeProject.load('myapp.xcodeproj/project.pbxproj')
project.save()

理论上   myapp.xcodeproj/project.pbxproj文件内容不会有任何修改的。
但是 该文件内容被修改了，本次提交修复了部分问题，其余地方不太确定暂未修改（还请作者自行校验）。

请知悉。
