### PR TITLE
add support for setting group path same as name while add folder

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -337,7 +337,7 @@ class ProjectFiles:
 
         return result != 0 and result == total
 
-    def add_folder(self, path, parent=None, excludes=None, recursive=True, create_groups=True, target_name=None,
+    def add_folder(self, path, parent=None, excludes=None, is_group_abspath=True, recursive=True, create_groups=True, target_name=None,
                    file_options=FileOptions()):
         """
         Given a directory, it will create the equivalent group structure and add all files in the process.
@@ -347,6 +347,9 @@ class ProjectFiles:
         :param path: OS path to the directory to be added.
         :param parent: Parent group to be added under
         :param excludes: list of regexs to ignore
+        :param is_group_abspath: set the path of group as abspath or same as name while add folder as groups. If
+                                 U has moved the folder as part of the project which will be moved to other PC, U
+                                 should set is_group_abspath False
         :param recursive: add folders recursively or stop in the first level
         :param create_groups: add folders recursively as groups or references
         :param target_name: Target name or list of target names where the file should be added (none for every target)
@@ -366,7 +369,11 @@ class ProjectFiles:
         if not create_groups and os.path.splitext(path)[1] not in ProjectFiles._SPECIAL_FOLDERS:
             return self.add_file(path, parent, target_name=target_name, force=False, file_options=file_options)
 
-        parent = self.get_or_create_group(os.path.split(path)[1], path, parent)
+        group_path = path
+        if not is_group_abspath:
+            group_path = os.path.split(path)[1]
+
+        parent = self.get_or_create_group(os.path.split(path)[1], group_path, parent)
 
         # iterate over the objects in the directory
         for child in os.listdir(path):

--- a/tests/pbxextensions/TestProjectFiles.py
+++ b/tests/pbxextensions/TestProjectFiles.py
@@ -319,6 +319,16 @@ class ProjectFilesTest(unittest.TestCase):
         self.assertEqual(project.objects.get_objects_in_section(u'PBXResourcesBuildPhase').__len__(), 2)
         self.assertEqual(build_file.__len__(), 2)
 
+    def testAddFolderWithPathSameAsName(self):
+        project = XcodeProject(self.obj, path="tests/project.pbxproj")
+        parent_group = project.get_or_create_group('parent_group')
+
+        #copy the samples to the project, and set its path same as name which is samples.
+        #so the samples group is along with project
+        shutil.copy2('samples', 'parent_group')
+        target_path = '/parent_group/samples'
+        project.add_folder(parent=parent_group, path=target_path, is_group_abspath=False)
+
     def testEmbedFrameworkInRightCopySection(self):
         project = XcodeProject(self.obj)
         self.assertEqual(project.objects.get_objects_in_section(u'PBXCopyFilesBuildPhase').__len__(), 1)


### PR DESCRIPTION
Hi kronenthaler,
Setting the path of Group same as its name, we can:
1. the group will be along with the project which was copied to anywhere or any PC
2. each one can change the files of the group after one has copied the group in a project, no need to worry about the group maybe referenced by other projects.