### PR TITLE
Add missing newline to end of file

### DIFF
--- a/pbxproj/XcodeProject.py
+++ b/pbxproj/XcodeProject.py
@@ -27,7 +27,7 @@ class XcodeProject(PBXGenericObject, ProjectFiles, ProjectFlags, ProjectGroups):
             path = self._pbxproj_path
 
         f = open(path, 'w')
-        f.write(self.__repr__())
+        f.write(self.__repr__() + "\n")
         f.close()
 
     def backup(self):


### PR DESCRIPTION
Some other utils (react-native link) were complaining about missing newline at the end
of the generated project file.