### PR TITLE
Render the name for a ShellScript as its comment, if present

### DIFF
--- a/pbxproj/pbxsections/PBXShellScriptBuildPhase.py
+++ b/pbxproj/pbxsections/PBXShellScriptBuildPhase.py
@@ -2,9 +2,10 @@ from pbxproj.pbxsections.PBXGenericBuildPhase import *
 
 
 class PBXShellScriptBuildPhase(PBXGenericBuildPhase):
+
     @classmethod
-    def create(cls, script, shell_path=u"/bin/sh", files=None, input_paths=None, output_paths=None, show_in_log='0'):
-        return cls().parse({
+    def create(cls, script, name=None, shell_path=u"/bin/sh", files=None, input_paths=None, output_paths=None, show_in_log='0'):
+        kwargs = {
             u'_id': cls._generate_id(),
             u'isa': cls.__name__,
             u'files': files if files else [],
@@ -15,7 +16,10 @@ class PBXShellScriptBuildPhase(PBXGenericBuildPhase):
             u'shellPath': shell_path,
             u'shellScript': script,
             u'showEnvVarsInLog': show_in_log
-        })
+        }
+        if name is not None:
+            kwargs[u'name'] = name
+        return cls().parse(kwargs)
 
     def _get_comment(self):
-        return u'ShellScript'
+        return getattr(self, 'name', u'ShellScript')

--- a/tests/pbxsections/TestPBXShellScriptBuildPhase.py
+++ b/tests/pbxsections/TestPBXShellScriptBuildPhase.py
@@ -6,3 +6,8 @@ class PBXShellScriptBuildPhaseTest(unittest.TestCase):
     def testGetComment(self):
         obj = PBXShellScriptBuildPhase()
         self.assertEqual(obj._get_comment(), u'ShellScript')
+
+    def testGetCommentWithName(self):
+        name = u'Run My Script Please'
+        obj = PBXShellScriptBuildPhase.create(script=u'/dev/null', name=name)
+        self.assertEqual(obj._get_comment(), name)


### PR DESCRIPTION
The Xcode editor UI allows you to specify a name for a shell script, with the result that it is written into the project file as a `name` field. But projects with named shell scripts were not having those preserved in their comments.

This change uses the `name` of a `ShellScript` as its comment (if it has one).