### PR TITLE
Handle fileRefs not existing for FBXBuildFile's

### DIFF
--- a/pbxproj/pbxsections/PBXBuildFile.py
+++ b/pbxproj/pbxsections/PBXBuildFile.py
@@ -35,7 +35,11 @@ class PBXBuildFile(PBXGenericObject):
                                                        indentation_increment=u'')
 
     def _get_comment(self):
-        return u'{0} in {1}'.format(self.fileRef._get_comment(), self._get_section())
+        if hasattr(self, 'fileRef'):
+            comment = self.fileRef._get_comment()
+        else:
+            comment = '(null)'
+        return u'{0} in {1}'.format(comment, self._get_section())
 
     def _get_section(self):
         objects = self.get_parent()

--- a/pbxproj/pbxsections/PBXBuildFile.py
+++ b/pbxproj/pbxsections/PBXBuildFile.py
@@ -35,10 +35,9 @@ class PBXBuildFile(PBXGenericObject):
                                                        indentation_increment=u'')
 
     def _get_comment(self):
+        comment = '(null)'
         if hasattr(self, 'fileRef'):
             comment = self.fileRef._get_comment()
-        else:
-            comment = '(null)'
         return u'{0} in {1}'.format(comment, self._get_section())
 
     def _get_section(self):

--- a/tests/pbxsections/TestPBXBuildFile.py
+++ b/tests/pbxsections/TestPBXBuildFile.py
@@ -24,6 +24,17 @@ class PBXBuildFileTest(unittest.TestCase):
 
         self.assertEqual(dobj.objects['1']._get_comment(), "real name in X")
 
+    def testGetCommentForNonExistentRef(self):
+        obj = {
+            'objects': {
+                'FDDF6A571C68E5B100D7A645': {'isa': 'PBXBuildFile'},
+                "X": {'isa': 'phase', 'name': 'X', 'files': ['FDDF6A571C68E5B100D7A645']}
+            }
+        }
+        dobj = XcodeProject().parse(obj)
+
+        self.assertEqual(dobj.objects['FDDF6A571C68E5B100D7A645']._get_comment(), "(null) in X")
+
     def testAddAttributesWithoutSettings(self):
         dobj = PBXBuildFile.create(PBXGenericObject())
 


### PR DESCRIPTION
This allows saving projects where one or more PBXBuildFile has an invalid reference. While the likely right thing to do in this case is to remove these from the project file, this can be hard when dealing with 3rd party projects that are not under your control. This change mimics what Xcode does in these scenarios. An example project that exhibits this can be found at https://github.com/facebook/react-native/blob/0.55-stable/React/React.xcodeproj/project.pbxproj

I have tested this by adding a new unit test to check the behavior and checked that I can load and save the above linked project.

Fixes https://github.com/kronenthaler/mod-pbxproj/issues/179.