### PR TITLE
Fixing export runOnlyForDeploymentPostprocessing flag 

### DIFF
--- a/pbxproj/pbxextensions/ProjectFlags.py
+++ b/pbxproj/pbxextensions/ProjectFlags.py
@@ -218,7 +218,7 @@ class ProjectFlags:
         :return:
         """
         for target in self.objects.get_targets(target_name):
-            shell = PBXShellScriptBuildPhase.create(script, input_paths=input_files, output_paths=output_files)
+            shell = PBXShellScriptBuildPhase.create(script, input_paths=input_files, output_paths=output_files, run_install_build=run_install_build)
 
             self.objects[shell.get_id()] = shell
             target.add_build_phase(shell, 0 if insert_before_compile else None)

--- a/tests/pbxextensions/TestProjectFlags.py
+++ b/tests/pbxextensions/TestProjectFlags.py
@@ -234,7 +234,7 @@ class ProjectFlagsTest(unittest.TestCase):
         project = XcodeProject(self.obj)
         project.add_run_script(u'ls -la', run_install_build=1)
 
-        self.assertEqual(project.objects[project.objects['1'].buildPhases[1]].runOnlyForDeploymentPostprocessing, 0)
+        self.assertEqual(project.objects[project.objects['1'].buildPhases[1]].runOnlyForDeploymentPostprocessing, 1)
 
     def testAddCodeSignAllTargetAllConfigurations(self):
         project = XcodeProject(self.obj)


### PR DESCRIPTION
Hi again @kronenthaler 

I just noticed during my formatting refactor on https://github.com/kronenthaler/mod-pbxproj/pull/303 I had missed passing the param through, which would explain the test breaking for me.

This PR sorts that and I've updated the tests too

Sorry for the mistake!