### PR TITLE
PBXLegacyTarget and PBXBuildRule support

### DIFF
--- a/pbxproj/pbxsections/PBXBuildRule.py
+++ b/pbxproj/pbxsections/PBXBuildRule.py
@@ -1,0 +1,6 @@
+from pbxproj import PBXGenericObject
+
+
+class PBXBuildRule(PBXGenericObject):
+    def _get_comment(self):
+        return 'PBXBuildRule'

--- a/pbxproj/pbxsections/XCConfigurationList.py
+++ b/pbxproj/pbxsections/XCConfigurationList.py
@@ -10,7 +10,7 @@ class XCConfigurationList(PBXGenericObject):
         objects = self.get_parent()
         target_id = self.get_id()
 
-        for obj in objects.get_objects_in_section('PBXNativeTarget', 'PBXAggregateTarget'):
+        for obj in objects.get_objects_in_section('PBXNativeTarget', 'PBXLegacyTarget', 'PBXAggregateTarget'):
             if target_id in obj.buildConfigurationList:
                 return obj.isa, obj.name
 

--- a/pbxproj/pbxsections/__init__.py
+++ b/pbxproj/pbxsections/__init__.py
@@ -1,4 +1,5 @@
 from pbxproj.pbxsections.PBXBuildFile import *
+from pbxproj.pbxsections.PBXBuildRule import *
 from pbxproj.pbxsections.PBXFileReference import *
 from pbxproj.pbxsections.PBXFrameworksBuildPhase import *
 from pbxproj.pbxsections.PBXProject import *

--- a/tests/pbxsections/TestXCConfigurationList.py
+++ b/tests/pbxsections/TestXCConfigurationList.py
@@ -11,7 +11,7 @@ class XCConfigurationListTest(unittest.TestCase):
 
         self.assertEqual(config._get_comment(), 'Build configuration list for TargetType "name"')
 
-    def testGetSectionOnTarget(self):
+    def testGetSectionOnNativeTarget(self):
         objs = objects(None).parse(
             {
                 '1': {
@@ -25,6 +25,21 @@ class XCConfigurationListTest(unittest.TestCase):
             })
         config = objs['2']
         self.assertEqual(config._get_comment(), 'Build configuration list for PBXNativeTarget "the-target-name"')
+
+    def testGetSectionOnLegacyTarget(self):
+        objs = objects(None).parse(
+            {
+                '1': {
+                    'isa': 'PBXLegacyTarget',
+                    'buildConfigurationList': ['2'],
+                    'name': 'the-target-name'
+                },
+                '2': {
+                    'isa': 'XCConfigurationList'
+                }
+            })
+        config = objs['2']
+        self.assertEqual(config._get_comment(), 'Build configuration list for PBXLegacyTarget "the-target-name"')
 
     def testGetSectionOnProject(self):
         objs = objects(None).parse(


### PR DESCRIPTION
This adds PBXLegacyTargets to the list of sections in the configuration list. This avoids an exception failure when saving projects with legacy targets.

This also adds support for PBXBuildRule sections, preserving the /* PBXBuildRule */ comment.

This fixes #319