### PR TITLE
Add XCLocalSwiftPackageReference support

### DIFF
--- a/pbxproj/pbxsections/XCLocalSwiftPackageReference.py
+++ b/pbxproj/pbxsections/XCLocalSwiftPackageReference.py
@@ -1,0 +1,14 @@
+from pbxproj import PBXGenericObject
+
+
+class XCLocalSwiftPackageReference(PBXGenericObject):
+    @classmethod
+    def create(cls, relative_path):
+        return cls().parse({
+            '_id': cls._generate_id(),
+            'isa': cls.__name__,
+            'relativePath': relative_path
+        })
+
+    def _get_comment(self):
+        return f'XCLocalSwiftPackageReference "{self.relativePath}"'

--- a/pbxproj/pbxsections/__init__.py
+++ b/pbxproj/pbxsections/__init__.py
@@ -18,3 +18,4 @@ from pbxproj.pbxsections.PBXReferenceProxy import *
 from pbxproj.pbxsections.PBXGroup import *
 from pbxproj.pbxsections.XCSwiftPackageProductDependency import *
 from pbxproj.pbxsections.XCRemoteSwiftPackageReference import *
+from pbxproj.pbxsections.XCLocalSwiftPackageReference import *

--- a/tests/pbxsections/TestXCLocalSwiftPackageReference.py
+++ b/tests/pbxsections/TestXCLocalSwiftPackageReference.py
@@ -1,0 +1,8 @@
+import unittest
+from pbxproj.pbxsections.XCLocalSwiftPackageReference import *
+
+
+class TestXCLocalSwiftPackageReference(unittest.TestCase):
+    def testGetComment(self):
+        obj = XCLocalSwiftPackageReference.create('MyPackage')
+        assert obj._get_comment() == 'XCLocalSwiftPackageReference "MyPackage"'


### PR DESCRIPTION
This PR fixes https://github.com/kronenthaler/mod-pbxproj/issues/340 by adding support for `XCLocalSwiftPackageReference` local package in Xcode.

I tested this on my Xcode project and it correctly parses the contents.