### PR TITLE
Fix build step parsing that includes newlines

### DIFF
--- a/pbxproj/PBXGenericObject.py
+++ b/pbxproj/PBXGenericObject.py
@@ -10,7 +10,8 @@ class PBXGenericObject(object):
     Generic class that creates internal attributes to match the structure of the tree used to create the element.
     Also, prints itself using the openstep format. Extensions might be required to insert comments on right places.
     """
-    _VALID_KEY_REGEX = re.compile(r'^[a-zA-Z0-9\\._/]*$')
+    # use negative look-ahead to avoid matching the newline character in multiline strings
+    _VALID_KEY_REGEX = re.compile(r'^[a-zA-Z0-9\\._/]*(?!\n)$')
     _ESCAPE_REPLACEMENTS = [
         ('\\', '\\\\'),
         ('\n', '\\n'),

--- a/tests/TestPBXGenericObject.py
+++ b/tests/TestPBXGenericObject.py
@@ -27,6 +27,7 @@ class PBXGenericObjectTest(unittest.TestCase):
 
     def testEscapeItem(self):
         assert PBXGenericObject._escape("/bin/sh") == "/bin/sh"
+        assert PBXGenericObject._escape("/bin/sh\n") == '"/bin/sh\\n"'
         assert PBXGenericObject._escape("abcdefghijklmnopqrstuvwyz0123456789") == \
                          "abcdefghijklmnopqrstuvwyz0123456789"
         assert PBXGenericObject._escape("some spaces") == '"some spaces"'


### PR DESCRIPTION
This PR fixes https://github.com/kronenthaler/mod-pbxproj/issues/341 where build steps that have newlines that match the escape regex are not quoted correctly.

The fix is to use a negative look ahead in the escape regex to make sure the string doesn't contain new lines.  If it does, run it through the usual escape logic which produces correct results.
