### PR TITLE
fix: support `productRef` when removing files

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -329,7 +329,7 @@ class ProjectFiles:
             for build_file_id in filter(lambda x: x in self.objects, build_phase.files):
                 build_file = self.objects[build_file_id]
 
-                if build_file.fileRef == file_ref.get_id():
+                if hasattr(build_file, 'fileRef') and build_file.fileRef == file_ref.get_id():
                     # remove the build file from the phase
                     build_phase.remove_build_file(build_file)
 
@@ -339,7 +339,11 @@ class ProjectFiles:
                 target.remove_build_phase(build_phase)
 
         # remove it iff it's removed from all targets or no build file reference it
-        if len([1 for x in self.objects.get_objects_in_section('PBXBuildFile') if x.fileRef == file_ref.get_id()]) != 0:
+        if len([
+            True
+            for x in self.objects.get_objects_in_section('PBXBuildFile')
+            if hasattr(x, 'fileRef') == file_ref.get_id()
+        ]) != 0:
             return True
 
         # remove the file from any groups if there is no reference from any target


### PR DESCRIPTION
fix the exception below:

```
  File "pbxproj/pbxextensions/ProjectFiles.py", line 332, in remove_file_by_id
    if build_file.fileRef == file_ref.get_id():
AttributeError: 'PBXBuildFile' object has no attribute 'fileRef'
```

Fixes #352