### PR TITLE
fix: support adding and removing Localizable.strings file

### DIFF
--- a/pbxproj/pbxextensions/ProjectGroups.py
+++ b/pbxproj/pbxextensions/ProjectGroups.py
@@ -62,7 +62,7 @@ class ProjectGroups:
         del self.objects[group.get_id()]
 
         # remove the reference from any other group object that could be containing it.
-        for other_group in self.objects.get_objects_in_section('PBXGroup'):
+        for other_group in self.objects.get_objects_in_section('PBXGroup', 'PBXVariantGroup'):
             other_group.remove_child(group)
 
         return True
@@ -87,14 +87,14 @@ class ProjectGroups:
 
         return True
 
-    def get_groups_by_name(self, name, parent=None):
+    def get_groups_by_name(self, name, parent=None, section='PBXGroup'):
         """
         Retrieve all groups matching the given name and optionally filtered by the given parent node.
         :param name: The name of the group that has to be returned
         :param parent: A PBXGroup object where the object has to be retrieved from. If None all matching groups are returned
         :return: An list of all matching groups
         """
-        groups = self.objects.get_objects_in_section('PBXGroup')
+        groups = self.objects.get_objects_in_section(section)
         groups = [group for group in groups if group.get_name() == name]
 
         if parent:
@@ -110,7 +110,7 @@ class ProjectGroups:
         :param parent: A PBXGroup object where the object has to be retrieved from. If None all matching groups are returned
         :return: An list of all matching groups
         """
-        groups = self.objects.get_objects_in_section('PBXGroup')
+        groups = self.objects.get_objects_in_section('PBXGroup', 'PBXVariantGroup')
         groups = [group for group in groups if group.get_path() == path]
 
         if parent:

--- a/pbxproj/pbxsections/PBXFileReference.py
+++ b/pbxproj/pbxsections/PBXFileReference.py
@@ -5,12 +5,12 @@ from pbxproj import PBXGenericObject
 
 class PBXFileReference(PBXGenericObject):
     @classmethod
-    def create(cls, path, tree='SOURCE_ROOT'):
+    def create(cls, path, name=None, tree='SOURCE_ROOT'):
         return cls().parse({
             '_id': cls._generate_id(),
             'isa': cls.__name__,
             'path': path,
-            'name': os.path.split(path)[1],
+            'name': name or os.path.split(path)[1],
             'sourceTree': tree
         })
 
@@ -48,7 +48,7 @@ class PBXFileReference(PBXGenericObject):
             build_file.remove(recursive)
 
         # search for each group that has a reference to the build file and remove it from it.
-        for group in parent.get_objects_in_section('PBXGroup'):
+        for group in parent.get_objects_in_section('PBXGroup', 'PBXVariantGroup'):
             if self.get_id() in group.children:
                 group.remove_child(self)
 

--- a/pbxproj/pbxsections/PBXVariantGroup.py
+++ b/pbxproj/pbxsections/PBXVariantGroup.py
@@ -1,0 +1,13 @@
+from pbxproj.pbxsections import PBXFileReference, PBXGroup
+
+
+class PBXVariantGroup(PBXGroup):
+    def add_child(self, child):
+        # Note: PBXVariantGroup is typically used for Localizable.strings
+        #       If other children type is needed e.g. PBXFileReference, edit this
+        #       function.
+        if not isinstance(child, PBXFileReference):
+            return False
+
+        self.children.append(child.get_id())
+        return True

--- a/pbxproj/pbxsections/__init__.py
+++ b/pbxproj/pbxsections/__init__.py
@@ -16,6 +16,7 @@ from pbxproj.pbxsections.PBXNativeTarget import *
 from pbxproj.pbxsections.PBXLegacyTarget import *
 from pbxproj.pbxsections.PBXReferenceProxy import *
 from pbxproj.pbxsections.PBXGroup import *
+from pbxproj.pbxsections.PBXVariantGroup import *
 from pbxproj.pbxsections.XCSwiftPackageProductDependency import *
 from pbxproj.pbxsections.XCRemoteSwiftPackageReference import *
 from pbxproj.pbxsections.XCLocalSwiftPackageReference import *


### PR DESCRIPTION
XCode project supports adding Localizable.strings file in multiple variants in which each language gets its own variant with the language code as the file "name" property.

Before
======

 - The file would be added under incorrect Resources section
 - The file ID would still be referenced in the Localizable.strings PBXVariantGroup section event though it has been removed
 - File cannot have a custom name

After
=====
 - The file can be added to the correct group via the `parent` parameter in ProjectFiles.add_file() method
 - When a file is removed, it's references are removed from both PBXGroup and PBXVariant group sections
 - Files can have custom names, differing from its path
 - More fixes for the `productRef` issue

Fun fact
========

This code is written on Linux, with help from my colleagues to debug the version once it's ready on their iOS devices.

Thanks!
=======
This project has been very helpful for us in openedx/openedx-app-ios. Thanks for creating it and double thanks for your fast triage for the other pull request.