### PR TITLE
Add PBXFileSystemSynchronizedRootGroup support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ coverage.xml
 .DS_Store
 tests/parent_group
 *.bak
+
+# VSCode files
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,24 @@ Do you want to fix an issue yourself? Great! some house rules:
 2. Provide unit tests for the case you have fixed. Pull request without unit test or PRs that decrease the coverage will not be approved until this changes.
 3. Adhere to the coding style and conventions of the project, for instance, target_name is used to specify the target across all functions that use this parameter. Changes will be requested on PRs that don't follow this.
 4. Write descriptive commit messages.
+
+### Getting Started
+Create virtual environment.
+```shell
+virtualenv -p python3 .venv
+```
+
+Activate the environment.
+```shell
+source .venv/bin/activate
+```
+
+Install development dependencies.
+```shell
+pip install -r dev-requirements.txt
+```
+
+Run tests.
+```shell
+pytest --cov-report=term --cov=../ --cov-branch tests
+```

--- a/pbxproj/pbxsections/PBXFileSystemSynchronizedRootGroup.py
+++ b/pbxproj/pbxsections/PBXFileSystemSynchronizedRootGroup.py
@@ -1,0 +1,17 @@
+from pbxproj import PBXGenericObject
+
+
+class PBXFileSystemSynchronizedRootGroup(PBXGenericObject):
+    @classmethod
+    def create(cls, explicit_file_types, explicit_folders, path, tree='SOURCE_ROOT'):
+        return cls().parse({
+            '_id': cls._generate_id(),
+            'isa': cls.__name__,
+            'explicitFileTypes': explicit_file_types,
+            'explicitFolders': explicit_folders,
+            'path': path,
+            'sourceTree': tree
+        })
+    
+    def _print_object(self, indent_depth='', entry_separator='\n', object_start='\n', indent_increment='\t'):
+        return super(PBXFileSystemSynchronizedRootGroup, self)._print_object('', entry_separator=' ', object_start='', indent_increment='')

--- a/pbxproj/pbxsections/__init__.py
+++ b/pbxproj/pbxsections/__init__.py
@@ -1,5 +1,6 @@
 from pbxproj.pbxsections.PBXBuildFile import *
 from pbxproj.pbxsections.PBXFileReference import *
+from pbxproj.pbxsections.PBXFileSystemSynchronizedRootGroup import *
 from pbxproj.pbxsections.PBXFrameworksBuildPhase import *
 from pbxproj.pbxsections.PBXProject import *
 from pbxproj.pbxsections.PBXResourcesBuildPhase import *

--- a/tests/pbxsections/TestPBXFileSystemSynchronizedRootGroup.py
+++ b/tests/pbxsections/TestPBXFileSystemSynchronizedRootGroup.py
@@ -1,0 +1,78 @@
+import unittest
+
+from pbxproj.pbxsections.PBXFileSystemSynchronizedRootGroup import PBXFileSystemSynchronizedRootGroup
+
+
+class PBXFileSystemSynchronizedRootGroupTests(unittest.TestCase):
+    """
+    Test suite for PBXFileSystemSynchronizedRootGroup class.
+    
+    PBXFileSystemSynchronizedRootGroup is a type of group in Xcode projects that's 
+    synchronized with the file system. These tests verify the creation behavior 
+    and special string representation formatting that's required for compatibility
+    with Xcode project format.
+    """
+    def testCreate(self):
+        """
+        Tests the create method of PBXFileSystemSynchronizedRootGroup with 
+        explicit file types, folders, path, and custom source tree parameter.
+        Verifies that all attributes are correctly set in the created object.
+        """
+        explicit_file_types = ['file1', 'file2']
+        explicit_folders = ['folder1', 'folder2']
+        path = 'some/path'
+        tree = 'SOURCE_ROOT'
+        
+        result = PBXFileSystemSynchronizedRootGroup.create(explicit_file_types, explicit_folders, path, tree)
+        
+        self.assertEqual(result.explicitFileTypes, explicit_file_types)
+        self.assertEqual(result.explicitFolders, explicit_folders)
+        self.assertEqual(result.path, path)
+        self.assertEqual(result.sourceTree, tree)
+        self.assertEqual(result.isa, 'PBXFileSystemSynchronizedRootGroup')
+        self.assertIsNotNone(result._id)
+    
+    def testCreateWithDefaultTree(self):
+        """
+        Tests the create method of PBXFileSystemSynchronizedRootGroup with default tree parameter.
+        Verifies that when no source tree is specified, it defaults to 'SOURCE_ROOT'.
+        """
+        explicit_file_types = ['file1', 'file2']
+        explicit_folders = ['folder1', 'folder2']
+        path = 'some/path'
+        
+        result = PBXFileSystemSynchronizedRootGroup.create(explicit_file_types, explicit_folders, path)
+        
+        self.assertEqual(result.sourceTree, 'SOURCE_ROOT')
+        
+    def testPrintObject(self):
+        """
+        Tests the _print_object method of PBXFileSystemSynchronizedRootGroup.
+        Verifies that the object is printed in a single line format (no newlines)
+        with correctly formatted attributes, overriding the parent class formatting.
+        This special formatting is important for compatibility with Xcode project format.
+        """
+        obj = {
+            '_id': 'test_id',
+            'isa': 'PBXFileSystemSynchronizedRootGroup',
+            'explicitFileTypes': ['file1', 'file2'],
+            'explicitFolders': ['folder1', 'folder2'],
+            'path': 'some/path',
+            'sourceTree': 'SOURCE_ROOT'
+        }
+        dobj = PBXFileSystemSynchronizedRootGroup().parse(obj)
+        
+        # Test that _print_object method overrides the parent's formatting
+        result = dobj._print_object()
+        
+        # Check that it's a single line representation (no newlines, compact format)
+        self.assertNotIn('\n', result)
+        self.assertIn('isa = PBXFileSystemSynchronizedRootGroup;', result)
+        self.assertIn('explicitFileTypes = (', result)
+        self.assertIn('file1', result)
+        self.assertIn('file2', result)
+        self.assertIn('explicitFolders = (', result)
+        self.assertIn('folder1', result)
+        self.assertIn('folder2', result)
+        self.assertIn('path = some/path;', result)
+        self.assertIn('sourceTree = SOURCE_ROOT;', result)


### PR DESCRIPTION
This PR addresses https://github.com/kronenthaler/mod-pbxproj/issues/362 by adding support for `PBXFileSystemSynchronizedRootGroup` which was introduced by Xcode16.

Summary of changes:
- Added corresponding module
- Added unit tests
- Added VSCode cruft into `.gitignore` to reduce noise
- Updated `CONTRIBUTING.md` to make it a little easier for newcomers to get started with the project.

Unit test results:
```
$ pytest --cov-report=term --cov=../ --cov-branch tests
...
Name                                                          Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------------------------------------------------
...
tests/pbxsections/TestPBXFileSystemSynchronizedRootGroup.py      35      0      0      0   100%
...
TOTAL                                                          3088     13    580     23    99%
=============================================== 252 passed in 0.71s ===========================
```