### PR TITLE
feat: add On-Demand Resources (ODR) tag support

### DIFF
--- a/pbxproj/pbxextensions/ProjectFiles.py
+++ b/pbxproj/pbxextensions/ProjectFiles.py
@@ -32,7 +32,7 @@ class FileOptions:
     Wrapper class for all file parameters required at the moment of adding a file to the project.
     """
     def __init__(self, create_build_files=True, weak=False, ignore_unknown_type=False, embed_framework=True,
-                 code_sign_on_copy=True, header_scope=HeaderScope.PROJECT, add_groups_relative=True):
+                 code_sign_on_copy=True, header_scope=HeaderScope.PROJECT, add_groups_relative=True, asset_tags=None):
         """
         Creates an object specifying options to be considered during the file creation into the project.
 
@@ -44,6 +44,8 @@ class FileOptions:
         :param header_scope: When adding a header file, adds the header as HeaderScope.PROJECT (default),
             HeaderScope.PRIVATE or HeaderScope.PUBLIC.
         :param add_groups_relative: Sets the group name to match the relative path is representing (default).
+        :param asset_tags: On-Demand Resource tags to assign to the file (list of strings or single string).
+            Tags are also registered in the project's KnownAssetTags.
         """
         self.create_build_files = create_build_files
         self.weak = weak
@@ -52,6 +54,7 @@ class FileOptions:
         self.code_sign_on_copy = code_sign_on_copy
         self.header_scope = header_scope
         self.add_groups_relative = add_groups_relative
+        self.asset_tags = asset_tags
 
     def get_attributes(self, file_ref, build_phase):
         if file_ref.get_file_type() not in ('wrapper.framework', 'wrapper.xcframework') and file_ref.get_file_type() != 'sourcecode.c.h':
@@ -612,11 +615,17 @@ class ProjectFiles:
 
             # create the build file and add it to the phase
             for target_build_phase in build_phases:
-                build_file = PBXBuildFile.create(file_ref, file_options.get_attributes(file_ref, target_build_phase))
+                build_file = PBXBuildFile.create(file_ref, file_options.get_attributes(file_ref, target_build_phase),
+                                                 asset_tags=file_options.asset_tags)
                 self.objects[build_file.get_id()] = build_file
                 target_build_phase.add_build_file(build_file)
 
                 results.append(build_file)
+
+        # register asset tags in the project's KnownAssetTags
+        if file_options.asset_tags is not None:
+            for project_obj in self.objects.get_objects_in_section('PBXProject'):
+                project_obj.add_known_asset_tags(file_options.asset_tags)
 
         return results
 

--- a/pbxproj/pbxsections/PBXBuildFile.py
+++ b/pbxproj/pbxsections/PBXBuildFile.py
@@ -9,18 +9,18 @@ class PBXBuildFile(PBXGenericObject):
         self._section = None
 
     @classmethod
-    def create(cls, file_ref, attributes=None, compiler_flags=None, is_product=False):
+    def create(cls, file_ref, attributes=None, compiler_flags=None, is_product=False, asset_tags=None):
         ref_key = 'productRef' if is_product else 'fileRef'
         return cls().parse({
             '_id': cls._generate_id(),
             'isa': cls.__name__,
             ref_key: file_ref.get_id(),
-            'settings': cls._get_settings(attributes, compiler_flags)
+            'settings': cls._get_settings(attributes, compiler_flags, asset_tags)
         })
 
     @classmethod
-    def _get_settings(cls, attributes=None, compiler_flags=None):
-        if attributes is None and compiler_flags is None:
+    def _get_settings(cls, attributes=None, compiler_flags=None, asset_tags=None):
+        if attributes is None and compiler_flags is None and asset_tags is None:
             return None
 
         settings = {}
@@ -33,6 +33,11 @@ class PBXBuildFile(PBXGenericObject):
             if not isinstance(compiler_flags, list):
                 compiler_flags = [compiler_flags]
             settings['COMPILER_FLAGS'] = ' '.join(compiler_flags)
+
+        if asset_tags is not None:
+            if not isinstance(asset_tags, list):
+                asset_tags = [asset_tags]
+            settings['ASSET_TAGS'] = asset_tags
 
         return settings
 
@@ -70,6 +75,36 @@ class PBXBuildFile(PBXGenericObject):
             return None
 
         return self.settings['ATTRIBUTES']
+
+    def get_asset_tags(self):
+        if 'settings' not in self or 'ASSET_TAGS' not in self.settings:
+            return None
+
+        return self.settings['ASSET_TAGS']
+
+    def add_asset_tags(self, asset_tags):
+        if not isinstance(asset_tags, list):
+            asset_tags = [asset_tags]
+
+        if 'settings' not in self:
+            self['settings'] = PBXGenericObject()
+
+        if 'ASSET_TAGS' not in self.settings:
+            self.settings['ASSET_TAGS'] = PBXList()
+
+        self.settings.ASSET_TAGS += asset_tags
+
+    def remove_asset_tags(self, asset_tags):
+        if 'settings' not in self or 'ASSET_TAGS' not in self.settings:
+            return False
+
+        if not isinstance(asset_tags, list):
+            asset_tags = [asset_tags]
+
+        for tag in asset_tags:
+            self.settings.ASSET_TAGS.remove(tag)
+
+        return self._clean_up_settings()
 
     def get_compiler_flags(self):
         if 'settings' not in self or 'COMPILER_FLAGS' not in self.settings:
@@ -138,6 +173,10 @@ class PBXBuildFile(PBXGenericObject):
         # no flags remain, remove the element
         if 'COMPILER_FLAGS' in self.settings and self.settings.COMPILER_FLAGS.__len__() == 0:
             del self.settings['COMPILER_FLAGS']
+
+        # no asset tags remain, remove the element
+        if 'ASSET_TAGS' in self.settings and self.settings.ASSET_TAGS.__len__() == 0:
+            del self.settings['ASSET_TAGS']
 
         if self.settings.get_keys().__len__() == 0:
             del self['settings']

--- a/pbxproj/pbxsections/PBXProject.py
+++ b/pbxproj/pbxsections/PBXProject.py
@@ -1,4 +1,4 @@
-from pbxproj import PBXGenericObject
+from pbxproj import PBXGenericObject, PBXList
 
 
 class PBXProvisioningTypes:
@@ -21,3 +21,36 @@ class PBXProject(PBXGenericObject):
             self.attributes.TargetAttributes[target.get_id()] = PBXGenericObject()
 
         self.attributes.TargetAttributes[target.get_id()]['ProvisioningStyle'] = provisioning_type
+
+    def add_known_asset_tags(self, tags):
+        if not isinstance(tags, list):
+            tags = [tags]
+
+        if 'attributes' not in self:
+            self['attributes'] = PBXGenericObject()
+
+        if 'KnownAssetTags' not in self.attributes:
+            self.attributes['KnownAssetTags'] = PBXList()
+
+        for tag in tags:
+            if tag not in self.attributes.KnownAssetTags:
+                self.attributes.KnownAssetTags.append(tag)
+
+    def remove_known_asset_tags(self, tags):
+        if 'attributes' not in self or 'KnownAssetTags' not in self.attributes:
+            return False
+
+        if not isinstance(tags, list):
+            tags = [tags]
+
+        for tag in tags:
+            if tag in self.attributes.KnownAssetTags:
+                self.attributes.KnownAssetTags.remove(tag)
+
+        if self.attributes.KnownAssetTags.__len__() == 0:
+            del self.attributes['KnownAssetTags']
+
+        if self.attributes.get_keys().__len__() == 0:
+            del self['attributes']
+
+        return True

--- a/tests/pbxextensions/TestProjectFiles.py
+++ b/tests/pbxextensions/TestProjectFiles.py
@@ -549,3 +549,52 @@ class ProjectFilesTest(unittest.TestCase):
 
         result = project.get_or_create_package_dependency('Some Product', '', {})
         assert result is not None
+
+    def testAddFileWithAssetTagsSetsAssetTagsOnBuildFile(self):
+        project = XcodeProject({
+            'objects': {
+                '2': {'isa': 'PBXAggregateTarget', 'name': 'report', 'buildConfigurationList': '4',
+                      'buildPhases': []},
+                '4': {'isa': 'XCConfigurationList', 'buildConfigurations': ['7', '8']},
+                '7': {'isa': 'XCBuildConfiguration', 'name': 'Release', 'id': '7'},
+                '8': {'isa': 'XCBuildConfiguration', 'name': 'Debug', 'id': '8'},
+                'project': {'isa': 'PBXProject'}
+            }
+        })
+
+        references = project.add_file("image.png", file_options=FileOptions(asset_tags=['level1']))
+
+        assert references[0].settings.ASSET_TAGS == ['level1']
+
+    def testAddFileWithAssetTagsRegistersTagsOnProject(self):
+        project = XcodeProject({
+            'objects': {
+                '2': {'isa': 'PBXAggregateTarget', 'name': 'report', 'buildConfigurationList': '4',
+                      'buildPhases': []},
+                '4': {'isa': 'XCConfigurationList', 'buildConfigurations': ['7', '8']},
+                '7': {'isa': 'XCBuildConfiguration', 'name': 'Release', 'id': '7'},
+                '8': {'isa': 'XCBuildConfiguration', 'name': 'Debug', 'id': '8'},
+                'project': {'isa': 'PBXProject'}
+            }
+        })
+
+        project.add_file("image.png", file_options=FileOptions(asset_tags=['level1', 'level2']))
+
+        project_obj = project.objects.get_objects_in_section('PBXProject')[0]
+        assert project_obj.attributes.KnownAssetTags == ['level1', 'level2']
+
+    def testAddFileWithoutAssetTagsDoesNotSetAssetTags(self):
+        project = XcodeProject({
+            'objects': {
+                '2': {'isa': 'PBXAggregateTarget', 'name': 'report', 'buildConfigurationList': '4',
+                      'buildPhases': []},
+                '4': {'isa': 'XCConfigurationList', 'buildConfigurations': ['7', '8']},
+                '7': {'isa': 'XCBuildConfiguration', 'name': 'Release', 'id': '7'},
+                '8': {'isa': 'XCBuildConfiguration', 'name': 'Debug', 'id': '8'},
+                'project': {'isa': 'PBXProject'}
+            }
+        })
+
+        references = project.add_file("image.png", file_options=FileOptions())
+
+        assert references[0]['settings'] is None

--- a/tests/pbxsections/TestPBXBuildFile.py
+++ b/tests/pbxsections/TestPBXBuildFile.py
@@ -213,3 +213,81 @@ class PBXBuildFileTest(unittest.TestCase):
         dobj = PBXBuildFile.create(obj, is_product=True)
 
         assert hasattr(dobj, "productRef")
+
+    def testGetAssetTagsWithoutSettings(self):
+        dobj = PBXBuildFile.create(PBXGenericObject())
+
+        assert dobj.get_asset_tags() is None
+
+    def testGetAssetTagsWithoutAssetTags(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), compiler_flags='x')
+
+        assert dobj.get_asset_tags() is None
+
+    def testGetAssetTagsWithAssetTags(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), asset_tags='level1')
+
+        tags = dobj.get_asset_tags()
+
+        assert tags is not None
+        assert tags == ['level1']
+
+    def testCreateWithAssetTagsList(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), asset_tags=['level1', 'level2'])
+
+        tags = dobj.get_asset_tags()
+
+        assert tags is not None
+        assert tags == ['level1', 'level2']
+
+    def testAddAssetTagsWithoutSettings(self):
+        dobj = PBXBuildFile.create(PBXGenericObject())
+
+        dobj.add_asset_tags('level1')
+
+        assert dobj.settings.ASSET_TAGS is not None
+        assert dobj.settings.ASSET_TAGS == ['level1']
+
+    def testAddAssetTagsList(self):
+        dobj = PBXBuildFile.create(PBXGenericObject())
+
+        dobj.add_asset_tags(['level1', 'level2'])
+
+        assert dobj.settings.ASSET_TAGS is not None
+        assert dobj.settings.ASSET_TAGS == ['level1', 'level2']
+
+    def testAddAssetTagsWithExistingTags(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), asset_tags='level1')
+
+        dobj.add_asset_tags('level2')
+
+        assert dobj.settings.ASSET_TAGS == ['level1', 'level2']
+
+    def testRemoveAssetTagsWithoutSettings(self):
+        dobj = PBXBuildFile.create(PBXGenericObject())
+
+        dobj.remove_asset_tags('level1')
+
+        assert dobj['settings'] is None
+
+    def testRemoveAssetTagsList(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), asset_tags=['level1', 'level2'])
+
+        dobj.remove_asset_tags(['level1', 'level2'])
+
+        assert dobj['settings'] is None
+
+    def testRemoveAssetTagsWithSettings(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), asset_tags=['level1'])
+
+        dobj.remove_asset_tags('level1')
+
+        assert dobj['settings'] is None
+
+    def testRemoveAssetTagsLeavesOtherSettings(self):
+        dobj = PBXBuildFile.create(PBXGenericObject(), asset_tags=['level1'], compiler_flags='-fno-arc')
+
+        dobj.remove_asset_tags('level1')
+
+        assert dobj['settings'] is not None
+        assert dobj.settings.COMPILER_FLAGS == '-fno-arc'

--- a/tests/pbxsections/TestPBXProject.py
+++ b/tests/pbxsections/TestPBXProject.py
@@ -28,6 +28,60 @@ class PBXProjectTest(unittest.TestCase):
 
         assert obj.attributes.TargetAttributes[u'1'].ProvisioningStyle == PBXProvisioningTypes.AUTOMATIC
 
+    def testAddKnownAssetTag(self):
+        obj = PBXProject()
+
+        obj.add_known_asset_tags('level1')
+
+        assert obj.attributes.KnownAssetTags == ['level1']
+
+    def testAddKnownAssetTagList(self):
+        obj = PBXProject()
+
+        obj.add_known_asset_tags(['level1', 'level2'])
+
+        assert obj.attributes.KnownAssetTags == ['level1', 'level2']
+
+    def testAddKnownAssetTagsWithExistingTags(self):
+        obj = PBXProject()
+        obj.add_known_asset_tags('level1')
+
+        obj.add_known_asset_tags('level2')
+
+        assert obj.attributes.KnownAssetTags == ['level1', 'level2']
+
+    def testAddKnownAssetTagNoDuplicates(self):
+        obj = PBXProject()
+        obj.add_known_asset_tags('level1')
+
+        obj.add_known_asset_tags('level1')
+
+        assert obj.attributes.KnownAssetTags == ['level1']
+
+    def testRemoveKnownAssetTag(self):
+        obj = PBXProject()
+        obj.add_known_asset_tags(['level1', 'level2'])
+
+        obj.remove_known_asset_tags('level1')
+
+        assert obj.attributes.KnownAssetTags == ['level2']
+
+    def testRemoveKnownAssetTagList(self):
+        obj = PBXProject()
+        obj.add_known_asset_tags(['level1', 'level2'])
+
+        obj.remove_known_asset_tags(['level1', 'level2'])
+
+        assert obj['attributes'] is None or 'KnownAssetTags' not in obj.attributes
+
+    def testRemoveKnownAssetTagNotPresent(self):
+        obj = PBXProject()
+
+        # should not raise
+        obj.remove_known_asset_tags('level1')
+
+        assert obj['attributes'] is None
+
     def testRetainProjectReferences(self):
         obj = PBXProject().parse({'projectReferences': [
 				{


### PR DESCRIPTION
## Problem

There was no programmatic way to assign On-Demand Resource tags to files in an Xcode project using `mod-pbxproj`. Users were forced to either mutate `.pbxproj` files directly via shell scripts, or use `PBXGenericObject` parsing as an undocumented workaround. This was raised in issue #298.

ODR requires two distinct mutations to the project file:
1. Setting `ASSET_TAGS` in the `settings` of a `PBXBuildFile` entry to associate a file with specific tags
2. Registering those same tags in `KnownAssetTags` under `attributes` in the `PBXProject` section

Neither was supported.

## Solution

**`PBXBuildFile`** — new methods following the same pattern as `ATTRIBUTES`:
- `get_asset_tags()` — returns the current `ASSET_TAGS` list for a build file
- `add_asset_tags(tags)` — adds one or more tags (string or list)
- `remove_asset_tags(tags)` — removes tags and cleans up empty settings
- `create()` now accepts `asset_tags=None`

**`PBXProject`** — new methods for managing the project-level tag registry:
- `add_known_asset_tags(tags)` — adds tags to `attributes.KnownAssetTags` (no duplicates)
- `remove_known_asset_tags(tags)` — removes tags and cleans up empty attributes

**`FileOptions`** — new `asset_tags=None` parameter for the high-level API. When `add_file()` is called with asset tags, the library automatically updates both the build file's `ASSET_TAGS` and the project's `KnownAssetTags` in one step.

## Usage

```python
project.add_file("resources/level1.dataset",
                 file_options=FileOptions(asset_tags=['level1', 'bonus-content']))
```

This produces the correct structure in the `.pbxproj`:

```
// PBXBuildFile section
AB1234 /* level1.dataset in Resources */ = {
    isa = PBXBuildFile;
    fileRef = AB5678 /* level1.dataset */;
    settings = {ASSET_TAGS = (level1, "bonus-content", ); };
};

// PBXProject section
attributes = {
    KnownAssetTags = (level1, "bonus-content", );
};
```

## Tests

- `TestPBXBuildFile` — 10 new tests covering `get_asset_tags`, `add_asset_tags`, `remove_asset_tags`, creation with tags, and cleanup of empty settings
- `TestPBXProject` — 7 new tests covering `add_known_asset_tags`, `remove_known_asset_tags`, duplicate prevention, and cleanup of empty attributes
- `TestProjectFiles` — 3 new integration tests verifying that `FileOptions(asset_tags=...)` correctly sets `ASSET_TAGS` on build files and registers tags in `KnownAssetTags`, and that files added without tags are unaffected

Closes #298