### PR TITLE
Fix pbxproj round-trip serialization drift

### DIFF
--- a/pbxproj/PBXGenericObject.py
+++ b/pbxproj/PBXGenericObject.py
@@ -11,7 +11,7 @@ class PBXGenericObject(object):
     Also, prints itself using the openstep format. Extensions might be required to insert comments on right places.
     """
     # use negative look-ahead to avoid matching the newline character in multiline strings
-    _VALID_KEY_REGEX = re.compile(r'^[a-zA-Z0-9\\._/]*(?!\n)$')
+    _VALID_KEY_REGEX = re.compile(r'^[a-zA-Z0-9\\._/$]*(?!\n)$')
     _ESCAPE_REPLACEMENTS = [
         ('\\', '\\\\'),
         ('\n', '\\n'),
@@ -46,7 +46,13 @@ class PBXGenericObject(object):
                 continue
 
             key = self._parse_string(key)
-            setattr(self, key, self._get_instance(key, value))
+            parsed_value = self._get_instance(key, value)
+
+            # Keep TestTargetID values as plain ids without synthetic inline comments.
+            if key == 'TestTargetID' and isinstance(parsed_value, PBXKey):
+                parsed_value._skip_comment = True
+
+            setattr(self, key, parsed_value)
 
         return self
 

--- a/pbxproj/PBXKey.py
+++ b/pbxproj/PBXKey.py
@@ -5,6 +5,9 @@ class PBXKey(str):
         return obj
 
     def __repr__(self):
+        if getattr(self, '_skip_comment', False):
+            return self.__str__()
+
         comment = self._get_comment()
         if comment is not None:
             comment = f' /* {comment} */'

--- a/pbxproj/pbxsections/PBXFileSystemSynchronizedBuildFileExceptionSet.py
+++ b/pbxproj/pbxsections/PBXFileSystemSynchronizedBuildFileExceptionSet.py
@@ -1,0 +1,6 @@
+from pbxproj import PBXGenericObject
+
+
+class PBXFileSystemSynchronizedBuildFileExceptionSet(PBXGenericObject):
+    def _get_comment(self):
+        return self.isa

--- a/pbxproj/pbxsections/XCConfigurationList.py
+++ b/pbxproj/pbxsections/XCConfigurationList.py
@@ -17,5 +17,7 @@ class XCConfigurationList(PBXGenericObject):
         projects = filter(lambda o: target_id in o.buildConfigurationList, objects.get_objects_in_section('PBXProject'))
         project = projects.__next__()
         target = objects[project.targets[0]]
-        name = target.name if hasattr(target, 'name') else target.productName
+        name = getattr(target, 'productName', None) or getattr(target, 'name', None)
+        if name is None:
+            name = getattr(project, 'name', '')
         return project.isa, name

--- a/pbxproj/pbxsections/__init__.py
+++ b/pbxproj/pbxsections/__init__.py
@@ -1,5 +1,6 @@
 from pbxproj.pbxsections.PBXBuildFile import *
 from pbxproj.pbxsections.PBXFileReference import *
+from pbxproj.pbxsections.PBXFileSystemSynchronizedBuildFileExceptionSet import *
 from pbxproj.pbxsections.PBXFileSystemSynchronizedRootGroup import *
 from pbxproj.pbxsections.PBXFrameworksBuildPhase import *
 from pbxproj.pbxsections.PBXProject import *

--- a/tests/TestPBXGenericObject.py
+++ b/tests/TestPBXGenericObject.py
@@ -27,6 +27,7 @@ class PBXGenericObjectTest(unittest.TestCase):
 
     def testEscapeItem(self):
         assert PBXGenericObject._escape("/bin/sh") == "/bin/sh"
+        assert PBXGenericObject._escape("$BUILT_PRODUCTS_DIR/Headers") == "$BUILT_PRODUCTS_DIR/Headers"
         assert PBXGenericObject._escape("/bin/sh\n") == '"/bin/sh\\n"'
         assert PBXGenericObject._escape("abcdefghijklmnopqrstuvwyz0123456789") == \
                          "abcdefghijklmnopqrstuvwyz0123456789"
@@ -105,3 +106,36 @@ class PBXGenericObjectTest(unittest.TestCase):
         assert dobj._resolve_comment('a') == 'A'
         assert dobj._resolve_comment('b') == 'B'
         assert dobj._resolve_comment('c') == None
+
+    def testPrintObjectNoCommentForTestTargetId(self):
+        obj = {
+            "objects": {
+                "AAAAAAAAAAAAAAAAAAAAAAAA": {
+                    "isa": "PBXNativeTarget",
+                    "name": "TestTarget",
+                    "buildConfigurationList": "CCCCCCCCCCCCCCCCCCCCCCCC",
+                    "buildPhases": []
+                },
+                "BBBBBBBBBBBBBBBBBBBBBBBB": {
+                    "isa": "PBXProject",
+                    "attributes": {
+                        "TargetAttributes": {
+                            "DDDDDDDDDDDDDDDDDDDDDDDD": {
+                                "TestTargetID": "AAAAAAAAAAAAAAAAAAAAAAAA"
+                            }
+                        }
+                    },
+                    "buildConfigurationList": "CCCCCCCCCCCCCCCCCCCCCCCC",
+                    "targets": ["AAAAAAAAAAAAAAAAAAAAAAAA"]
+                },
+                "CCCCCCCCCCCCCCCCCCCCCCCC": {
+                    "isa": "XCConfigurationList",
+                    "buildConfigurations": []
+                }
+            }
+        }
+
+        dobj = PBXGenericObject().parse(obj)
+
+        assert "TestTargetID = AAAAAAAAAAAAAAAAAAAAAAAA;" in dobj.__repr__()
+        assert "TestTargetID = AAAAAAAAAAAAAAAAAAAAAAAA /* TestTarget */;" not in dobj.__repr__()

--- a/tests/pbxsections/TestPBXFileSystemSynchronizedBuildFileExceptionSet.py
+++ b/tests/pbxsections/TestPBXFileSystemSynchronizedBuildFileExceptionSet.py
@@ -1,0 +1,40 @@
+import unittest
+
+from pbxproj.PBXObjects import objects
+
+
+class PBXFileSystemSynchronizedBuildFileExceptionSetTests(unittest.TestCase):
+    def testCommentsArePreservedInReferences(self):
+        obj = {
+            "AAAAAAAAAAAAAAAAAAAAAAAA": {
+                "isa": "PBXFileSystemSynchronizedBuildFileExceptionSet",
+                "membershipExceptions": [
+                    "Sample.swift"
+                ],
+                "target": "BBBBBBBBBBBBBBBBBBBBBBBB"
+            },
+            "BBBBBBBBBBBBBBBBBBBBBBBB": {
+                "isa": "PBXNativeTarget",
+                "name": "Tests",
+                "buildConfigurationList": "CCCCCCCCCCCCCCCCCCCCCCCC",
+                "buildPhases": []
+            },
+            "CCCCCCCCCCCCCCCCCCCCCCCC": {
+                "isa": "XCConfigurationList",
+                "buildConfigurations": []
+            },
+            "DDDDDDDDDDDDDDDDDDDDDDDD": {
+                "isa": "PBXFileSystemSynchronizedRootGroup",
+                "exceptions": ["AAAAAAAAAAAAAAAAAAAAAAAA"],
+                "explicitFileTypes": {},
+                "explicitFolders": [],
+                "path": "QuickAccept",
+                "sourceTree": "<group>"
+            }
+        }
+
+        dobj = objects(None).parse(obj)
+        printed = dobj._print_object()
+
+        assert "AAAAAAAAAAAAAAAAAAAAAAAA /* PBXFileSystemSynchronizedBuildFileExceptionSet */ =" in printed
+        assert "exceptions = (AAAAAAAAAAAAAAAAAAAAAAAA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, );" in printed

--- a/tests/pbxsections/TestXCConfigurationList.py
+++ b/tests/pbxsections/TestXCConfigurationList.py
@@ -47,8 +47,39 @@ class XCConfigurationListTest(unittest.TestCase):
                 "1": {
                     "isa": "PBXProject",
                     "buildConfigurationList": ['2'],
-                    "targets": ["1"],
-                    "productName": "the-target-name"
+                    "targets": ["3"],
+                },
+                "3": {
+                    "isa": "PBXNativeTarget",
+                    "name": "the-target-name",
+                    "productName": "the-product-name",
+                    "buildConfigurationList": ['4']
+                },
+                "4": {
+                    'isa': 'XCConfigurationList'
+                },
+                "2": {
+                    'isa': 'XCConfigurationList'
+                }
+            })
+        config = objs['2']
+        assert config._get_comment() == 'Build configuration list for PBXProject "the-product-name"'
+
+    def testGetSectionOnProjectFallbackToTargetName(self):
+        objs = objects(None).parse(
+            {
+                "1": {
+                    "isa": "PBXProject",
+                    "buildConfigurationList": ['2'],
+                    "targets": ["3"],
+                },
+                "3": {
+                    "isa": "PBXNativeTarget",
+                    "name": "the-target-name",
+                    "buildConfigurationList": ['4']
+                },
+                "4": {
+                    'isa': 'XCConfigurationList'
                 },
                 "2": {
                     'isa': 'XCConfigurationList'


### PR DESCRIPTION
## Problem

A no-op load/save cycle was modifying modern pbxproj files in ways that was unexpected. In a real project file this produced unrelated diffs, including:

- missing comments for PBXFileSystemSynchronizedBuildFileExceptionSet IDs
- forced quoting of bare shell variable tokens (for example
  $PROJECT_OUTPUT_VAR)
- injected inline target comments for TestTargetID values
- PBXProject build configuration list comment drift (for example
  "Sample.App" changing to "Sample")

## Root Cause

The serializer needed additional support for newer pbxproj section types and had a few
formatting/comment-generation behaviors that did not preserve existing
representation in some project files.

## Changes

- add PBXFileSystemSynchronizedBuildFileExceptionSet section model and register
  it in pbxsections imports
- allow bare "$" shell-variable tokens in PBXGenericObject escaping rules
- mark TestTargetID PBXKey values to suppress synthetic inline comments during
  rendering
- update XCConfigurationList PBXProject name derivation to prefer target
  productName, then fallback safely
- add regression tests for:
  - synchronized exception-set comment preservation
  - shell-variable escaping behavior
  - TestTargetID comment suppression
  - XCConfigurationList PBXProject naming behavior and fallback

## Validation

- Reproduced issue with round-trip load/save on a real copied project.pbxproj
  file.
- Before fix: 125-line diff from a no-op save.
- After fix: 0-line diff from a no-op save.
- Added intentional tiny edit and re-saved; no unrelated serialization drift.

## Tests

- ran: pytest --cov-report=term --cov=../ --cov-branch tests
- result: 255 passed